### PR TITLE
Actualizar estado de conexión y detener monitoreo térmico al desconectar del cooler

### DIFF
--- a/app/src/main/java/com/hitomatito/redmagicooler/MainActivity.kt
+++ b/app/src/main/java/com/hitomatito/redmagicooler/MainActivity.kt
@@ -390,8 +390,15 @@ class MainActivity : ComponentActivity() {
             bluetoothGatt = null
             fanCharacteristic = null
             lightCharacteristic = null
+            isConnected = false  // CRÍTICO: Actualizar estado de conexión
             isConnecting = false
             statusMessage = "Desconectado"
+            
+            // Detener monitoreo térmico si no hay servicio automático corriendo
+            if (!isServiceRunning(CoolerService::class.java)) {
+                thermalMonitor.stopMonitoring()
+            }
+            
             Log.d(TAG, "Desconectado del cooler")
         } catch (e: SecurityException) {
             Log.e(TAG, "SecurityException al desconectar: ${e.message}", e)


### PR DESCRIPTION
Esta solicitud de extracción realiza una mejora crucial en la lógica de desconexión de Bluetooth en `MainActivity.kt`, lo que garantiza que el estado de conexión de la aplicación se actualice con precisión y que la monitorización térmica se detenga cuando corresponda.

Gestión del estado de la conexión Bluetooth:

* Establece `isConnected` en `false` al desconectarse del enfriador para reflejar con precisión el estado de la conexión.

Control de monitorización térmica:

* Detiene `thermalMonitor` si el servicio automático `CoolerService` no se está ejecutando, lo que evita la monitorización innecesaria tras la desconexión.