### PR TITLE
fix: Agregar dependencia material-icons-core para resolver errores de compilación por referencias a Icons

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.core)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-agp = "9.1.0"
-kotlin = "2.2.21"
-coreKtx = "1.17.0"
+agp = "9.2.1"
+kotlin = "2.3.21"
+coreKtx = "1.18.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.2"
-composeBom = "2024.09.00"
-kotlinxCoroutines = "1.10.2"
-workRuntimeKtx = "2.10.0"
-navigationCompose = "2.8.5"
+activityCompose = "1.13.0"
+composeBom = "2026.05.00"
+kotlinxCoroutines = "1.11.0"
+workRuntimeKtx = "2.11.2"
+navigationCompose = "2.9.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +27,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Wed Dec 31 14:03:21 PET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Esta solicitud de extracción actualiza las dependencias y herramientas de compilación del proyecto a versiones más recientes y añade compatibilidad con Material Icons en Jetpack Compose. Los principales cambios se agrupan a continuación por tema:

**Actualizaciones de dependencias y herramientas de compilación:**

* Se actualizó Gradle a la versión `9.4.1` en `gradle-wrapper.properties` para garantizar la compatibilidad con el último complemento de Android Gradle.

* Se actualizaron el complemento de Android Gradle, Kotlin y varias bibliotecas de AndroidX a sus últimas versiones en `gradle/libs.versions.toml` para mejorar la estabilidad y el acceso a nuevas funciones.

**Mejoras en Jetpack Compose:**

* Se añadió la dependencia `androidx.compose.material.icons.core` para admitir Material Icons en la interfaz de usuario de Compose en `app/build.gradle.kts` y se definió en `gradle/libs.versions.toml`. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R46) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR30)